### PR TITLE
Faster decode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
 # Install build dependencies
 USER root
 RUN apt-get -y update && apt-get --no-install-recommends -y install \
-        libpcap-dev libtbb-dev libboost-program-options-dev \
+        libpcap-dev libboost-program-options-dev \
         autoconf automake
 USER kat
 
@@ -43,7 +43,7 @@ LABEL maintainer="sdpdev+katsdpdigitisercapture@ska.ac.za"
 # protocols in /etc/protocols).
 USER root
 RUN apt-get -y update && apt-get --no-install-recommends -y install \
-        libpcap0.8 libtbb2 hwloc-nox netbase && \
+        libpcap0.8 hwloc-nox netbase && \
     rm -rf /var/lib/apt/lists/*
 USER kat
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
 CXXFLAGS = -std=c++11 -Wall -g -pthread $(shell pkg-config --cflags spead2) -O3
-LDFLAGS = $(shell pkg-config --libs --static spead2) -lboost_program_options -lboost_system -pthread -ltbb
+LDFLAGS = $(shell pkg-config --libs --static spead2) -lboost_program_options -lboost_system -pthread
 
 all: digitiser_decode
 

--- a/digitiser_capture.py
+++ b/digitiser_capture.py
@@ -29,8 +29,6 @@ def parse_args():
     parser.add_argument('-s', '--seconds', type=float, default=5, help='Length of capture')
     parser.add_argument('--heaps', type=int, help='Maximum number of heaps to convert')
     parser.add_argument('--keep', action='store_true', help='Do not delete the pcap files')
-    parser.add_argument('--non-icd', action='store_true',
-                        help='Assume digitiser is not ICD compliant')
     return parser.parse_args()
 
 
@@ -65,8 +63,6 @@ def main():
             return 1
 
         decode_cmd = ['digitiser_decode']
-        if args.non_icd:
-            decode_cmd.append('--non-icd')
         if args.heaps is not None:
             decode_cmd.extend(['--heaps', str(args.heaps)])
         decode_cmd.extend([pcap_file.name, args.output])

--- a/digitiser_decode.cpp
+++ b/digitiser_decode.cpp
@@ -231,6 +231,7 @@ static std::vector<std::int16_t> decode_10bit(const std::uint8_t *data, std::siz
         _mm_storeu_si128(y_ptr + 0xe, _mm256_extracti128_si256(y01234567_p3, 1));
         _mm_storeu_si128(y_ptr + 0xf, _mm256_extracti128_si256(y89abcdef_p3, 1));
     }
+    _mm256_zeroupper();
     return out;
 }
 

--- a/digitiser_decode.cpp
+++ b/digitiser_decode.cpp
@@ -73,7 +73,7 @@ template<int left>
 [[gnu::target("avx2")]]
 static inline __m256i extr(__m256i in)
 {
-    static_assert(0 <= left && left <= 22, "left is out of ange");
+    static_assert(0 <= left && left <= 22, "left is out of range");
     if (left)
         return _mm256_srai_epi32(_mm256_slli_epi32(in, left), 22);
     else


### PR DESCRIPTION
Speed things up with an AVX2-optimised decoding routine. This is fast enough that it's no longer necessary to use TBB to get good performance (it was actually slowing things down), which is nice because the code was no longer compiling with the latest TBB.

Additionally, remove the --non-icd option, since the digitisers have been ICD-compliant for a long time at this point. That avoids needing to implement support for it in the AVX2 codepath.